### PR TITLE
fix: Install socket_client package in development mode in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,9 @@ WORKDIR /app
 # Copy application code
 COPY --chown=appuser:appuser . .
 
+# Install the package in development mode
+RUN pip install -e .
+
 # Create necessary directories
 RUN mkdir -p logs tmp && \
     chown -R appuser:appuser /app


### PR DESCRIPTION
## Problem

The socket client deployment was failing with  because the Dockerfile was not properly installing the package.

## Solution

- Add Obtaining file:///Users/yurisa2/petrosa/petrosa-socket-client
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: websockets>=12.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (15.0.1)
Requirement already satisfied: nats-py>=2.0.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (2.6.0)
Requirement already satisfied: requests>=2.31.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (2.32.3)
Requirement already satisfied: python-dotenv>=1.0.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (1.0.0)
Requirement already satisfied: pydantic<3.0.0,>=2.0.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (2.6.1)
Requirement already satisfied: structlog>=23.0.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (23.2.0)
Requirement already satisfied: opentelemetry-api>=1.20.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (1.21.0)
Requirement already satisfied: opentelemetry-distro>=0.41b0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (0.42b0)
Requirement already satisfied: opentelemetry-exporter-otlp-proto-grpc>=1.20.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (1.21.0)
Requirement already satisfied: opentelemetry-exporter-otlp-proto-http>=1.20.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (1.21.0)
Requirement already satisfied: opentelemetry-instrumentation>=0.41b0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (0.42b0)
Requirement already satisfied: opentelemetry-instrumentation-logging>=0.41b0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (0.42b0)
Requirement already satisfied: opentelemetry-instrumentation-requests>=0.41b0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (0.42b0)
Requirement already satisfied: opentelemetry-instrumentation-urllib3>=0.41b0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (0.42b0)
Requirement already satisfied: opentelemetry-sdk>=1.20.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (1.21.0)
Requirement already satisfied: opentelemetry-semantic-conventions>=0.41b0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (0.42b0)
Requirement already satisfied: typer>=0.9.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (0.16.0)
Requirement already satisfied: orjson>=3.9.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (3.11.2)
Requirement already satisfied: asyncio-mqtt>=0.16.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (0.16.1)
Requirement already satisfied: pybreaker>=1.0.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (1.4.0)
Requirement already satisfied: python-dateutil>=2.8.2 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (2.9.0.post0)
Requirement already satisfied: cryptography>=41.0.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (45.0.3)
Requirement already satisfied: aiohttp>=3.8.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from petrosa-socket-client==1.0.0) (3.8.5)
Requirement already satisfied: annotated-types>=0.4.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from pydantic<3.0.0,>=2.0.0->petrosa-socket-client==1.0.0) (0.7.0)
Requirement already satisfied: pydantic-core==2.16.2 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from pydantic<3.0.0,>=2.0.0->petrosa-socket-client==1.0.0) (2.16.2)
Requirement already satisfied: typing-extensions>=4.6.1 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from pydantic<3.0.0,>=2.0.0->petrosa-socket-client==1.0.0) (4.14.0)
Requirement already satisfied: attrs>=17.3.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from aiohttp>=3.8.0->petrosa-socket-client==1.0.0) (25.3.0)
Requirement already satisfied: charset-normalizer<4.0,>=2.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from aiohttp>=3.8.0->petrosa-socket-client==1.0.0) (3.4.2)
Requirement already satisfied: multidict<7.0,>=4.5 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from aiohttp>=3.8.0->petrosa-socket-client==1.0.0) (6.0.2)
Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from aiohttp>=3.8.0->petrosa-socket-client==1.0.0) (4.0.2)
Requirement already satisfied: yarl<2.0,>=1.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from aiohttp>=3.8.0->petrosa-socket-client==1.0.0) (1.8.1)
Requirement already satisfied: frozenlist>=1.1.1 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from aiohttp>=3.8.0->petrosa-socket-client==1.0.0) (1.3.3)
Requirement already satisfied: aiosignal>=1.1.2 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from aiohttp>=3.8.0->petrosa-socket-client==1.0.0) (1.2.0)
Requirement already satisfied: idna>=2.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from yarl<2.0,>=1.0->aiohttp>=3.8.0->petrosa-socket-client==1.0.0) (3.10)
Requirement already satisfied: paho-mqtt>=1.6.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from asyncio-mqtt>=0.16.0->petrosa-socket-client==1.0.0) (2.1.0)
Requirement already satisfied: cffi>=1.14 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from cryptography>=41.0.0->petrosa-socket-client==1.0.0) (1.17.1)
Requirement already satisfied: pycparser in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from cffi>=1.14->cryptography>=41.0.0->petrosa-socket-client==1.0.0) (2.22)
Requirement already satisfied: deprecated>=1.2.6 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from opentelemetry-api>=1.20.0->petrosa-socket-client==1.0.0) (1.2.14)
Requirement already satisfied: importlib-metadata<7.0,>=6.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from opentelemetry-api>=1.20.0->petrosa-socket-client==1.0.0) (6.11.0)
Requirement already satisfied: zipp>=0.5 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from importlib-metadata<7.0,>=6.0->opentelemetry-api>=1.20.0->petrosa-socket-client==1.0.0) (3.22.0)
Requirement already satisfied: wrapt<2,>=1.10 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from deprecated>=1.2.6->opentelemetry-api>=1.20.0->petrosa-socket-client==1.0.0) (1.17.2)
Requirement already satisfied: setuptools>=16.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from opentelemetry-instrumentation>=0.41b0->petrosa-socket-client==1.0.0) (80.9.0)
Requirement already satisfied: backoff<3.0.0,>=1.10.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from opentelemetry-exporter-otlp-proto-grpc>=1.20.0->petrosa-socket-client==1.0.0) (2.2.1)
Requirement already satisfied: googleapis-common-protos~=1.52 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from opentelemetry-exporter-otlp-proto-grpc>=1.20.0->petrosa-socket-client==1.0.0) (1.61.0)
Requirement already satisfied: grpcio<2.0.0,>=1.0.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from opentelemetry-exporter-otlp-proto-grpc>=1.20.0->petrosa-socket-client==1.0.0) (1.72.1)
Requirement already satisfied: opentelemetry-exporter-otlp-proto-common==1.21.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from opentelemetry-exporter-otlp-proto-grpc>=1.20.0->petrosa-socket-client==1.0.0) (1.21.0)
Requirement already satisfied: opentelemetry-proto==1.21.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from opentelemetry-exporter-otlp-proto-grpc>=1.20.0->petrosa-socket-client==1.0.0) (1.21.0)
Requirement already satisfied: protobuf<5.0,>=3.19 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from opentelemetry-proto==1.21.0->opentelemetry-exporter-otlp-proto-grpc>=1.20.0->petrosa-socket-client==1.0.0) (4.25.8)
Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from requests>=2.31.0->petrosa-socket-client==1.0.0) (2.4.0)
Requirement already satisfied: certifi>=2017.4.17 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from requests>=2.31.0->petrosa-socket-client==1.0.0) (2025.4.26)
Requirement already satisfied: opentelemetry-util-http==0.42b0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from opentelemetry-instrumentation-requests>=0.41b0->petrosa-socket-client==1.0.0) (0.42b0)
Requirement already satisfied: six>=1.5 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from python-dateutil>=2.8.2->petrosa-socket-client==1.0.0) (1.17.0)
Requirement already satisfied: click>=8.0.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from typer>=0.9.0->petrosa-socket-client==1.0.0) (8.2.1)
Requirement already satisfied: shellingham>=1.3.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from typer>=0.9.0->petrosa-socket-client==1.0.0) (1.5.4)
Requirement already satisfied: rich>=10.11.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from typer>=0.9.0->petrosa-socket-client==1.0.0) (14.0.0)
Requirement already satisfied: markdown-it-py>=2.2.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from rich>=10.11.0->typer>=0.9.0->petrosa-socket-client==1.0.0) (3.0.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from rich>=10.11.0->typer>=0.9.0->petrosa-socket-client==1.0.0) (2.19.1)
Requirement already satisfied: mdurl~=0.1 in /Users/yurisa2/anaconda3/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich>=10.11.0->typer>=0.9.0->petrosa-socket-client==1.0.0) (0.1.2)
Building wheels for collected packages: petrosa-socket-client
  Building editable for petrosa-socket-client (pyproject.toml): started
  Building editable for petrosa-socket-client (pyproject.toml): finished with status 'done'
  Created wheel for petrosa-socket-client: filename=petrosa_socket_client-1.0.0-0.editable-py3-none-any.whl size=8012 sha256=b63672f8341157846ef11b8237eae2084e9ebdc341e68a3dacb2cc36c4727987
  Stored in directory: /private/var/folders/yt/29knn3cd3h15yfy1kdwxhlj80000gn/T/pip-ephem-wheel-cache-tqbence0/wheels/cf/ea/1e/4f630d987303cecfc007931fce1e1dfa5c94b5bbddee2a135a
Successfully built petrosa-socket-client
Installing collected packages: petrosa-socket-client
Successfully installed petrosa-socket-client-1.0.0 to the Dockerfile to install the socket_client package in development mode
- This ensures the  module is available for the  command
- Fixes the critical WebSocket connection issue that was preventing new pods from starting

## Testing

- The fix ensures that the module is properly installed and available
- This should resolve the CrashLoopBackOff issue with new socket client pods
- Existing working pods (v1.0.61) will continue to function normally

## Impact

- Critical fix for WebSocket connectivity
- Enables proper deployment of new socket client instances
- Maintains compatibility with existing working deployments