### PR TITLE
fix: Add version protection and compliance improvements

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -62,7 +62,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        slug: PetroSa2/petrosa-binance-data-extractor
+        slug: PetroSa2/petrosa-socket-client
 
   security-scan:
     name: Security Scan

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Standardized Makefile for Petrosa Systems
 # Provides consistent development and testing procedures across all services
 
-.PHONY: help setup install install-dev clean format lint type-check unit integration e2e test security build container deploy pipeline pre-commit pre-commit-install pre-commit-run coverage coverage-html coverage-check
+.PHONY: help setup install install-dev clean format lint type-check unit integration e2e test security build container deploy pipeline pre-commit pre-commit-install pre-commit-run coverage coverage-html coverage-check version-check version-info version-debug install-git-hooks
 
 # Default target
 help:
@@ -45,7 +45,11 @@ help:
 	@echo "  pipeline       - Run complete CI/CD pipeline"
 	@echo ""
 	@echo "📊 Utilities:"
-	@echo "  k8s-status     - Check Kubernetes deployment status"
+	@echo "🔢 Version Management:"
+	@echo "  version-check  - Check VERSION_PLACEHOLDER integrity"
+	@echo "  version-info   - Show version information"
+	@echo "  version-debug  - Debug version issues"
+	@echo "  install-git-hooks - Install VERSION_PLACEHOLDER protection hooks"	@echo "  k8s-status     - Check Kubernetes deployment status"
 	@echo "  k8s-logs       - View Kubernetes logs"
 	@echo "  k8s-clean      - Clean up Kubernetes resources"
 	@echo "  run-local      - Run socket client locally"
@@ -245,3 +249,41 @@ dev: setup format lint type-check test
 # Quick production check
 prod: format lint type-check test security build container
 	@echo "✅ Production readiness check completed!"
+
+# Version Management
+version-check:
+	@echo "🔍 Checking VERSION_PLACEHOLDER integrity..."
+	@if [ -f "scripts/version-manager.sh" ]; then \
+		./scripts/version-manager.sh validate; \
+	else \
+		echo "❌ scripts/version-manager.sh not found"; \
+		exit 1; \
+	fi
+
+version-info:
+	@echo "📦 Version Information:"
+	@if [ -f "scripts/version-manager.sh" ]; then \
+		./scripts/version-manager.sh info; \
+	else \
+		echo "❌ scripts/version-manager.sh not found"; \
+		exit 1; \
+	fi
+
+version-debug:
+	@echo "🐛 Version Debug Information:"
+	@if [ -f "scripts/version-manager.sh" ]; then \
+		./scripts/version-manager.sh debug; \
+	else \
+		echo "❌ scripts/version-manager.sh not found"; \
+		exit 1; \
+	fi
+
+install-git-hooks:
+	@echo "🔧 Installing git hooks for VERSION_PLACEHOLDER protection..."
+	@if [ -f "scripts/install-git-hooks.sh" ]; then \
+		chmod +x scripts/install-git-hooks.sh; \
+		./scripts/install-git-hooks.sh; \
+	else \
+		echo "❌ scripts/install-git-hooks.sh not found"; \
+		exit 1; \
+	fi

--- a/README.md
+++ b/README.md
@@ -405,3 +405,4 @@ For support and questions:
 - [Petrosa Trade Engine](https://github.com/petrosa/petrosa-tradeengine) - Trading engine
 - [Petrosa Data Extractor](https://github.com/petrosa/petrosa-binance-data-extractor) - Historical data extraction
 # Trigger deployment with updated kubeconfig
+# Test deployment with updated kubeconfig

--- a/README.md
+++ b/README.md
@@ -404,3 +404,4 @@ For support and questions:
 - [Petrosa TA Bot](https://github.com/petrosa/petrosa-bot-ta-analysis) - Technical analysis bot
 - [Petrosa Trade Engine](https://github.com/petrosa/petrosa-tradeengine) - Trading engine
 - [Petrosa Data Extractor](https://github.com/petrosa/petrosa-binance-data-extractor) - Historical data extraction
+# Trigger deployment with updated kubeconfig

--- a/docs/CURSOR_AI_VERSION_RULES.md
+++ b/docs/CURSOR_AI_VERSION_RULES.md
@@ -1,0 +1,114 @@
+# CURSOR AI VERSION MANAGEMENT RULES
+
+## 🚨 CRITICAL: NEVER MODIFY VERSION_PLACEHOLDER
+
+### What VERSION_PLACEHOLDER Is
+- **Intentional placeholder** in Kubernetes manifests
+- **Automatically replaced** by CI/CD pipeline during deployment
+- **Part of the deployment system** - NOT a bug to fix
+- **Ensures consistent versioning** across all Petrosa systems
+
+### What Cursor AI Should NEVER Do
+❌ Replace VERSION_PLACEHOLDER with specific versions (v1.0.1, latest, etc.)
+❌ Suggest "fixing" VERSION_PLACEHOLDER in Kubernetes manifests
+❌ Commit manifests with real versions instead of placeholders
+❌ Change VERSION_PLACEHOLDER to any other value
+❌ "Help" by replacing placeholders with actual versions
+
+### What Cursor AI Should Do
+✅ Leave VERSION_PLACEHOLDER exactly as is in all k8s/ files
+✅ Understand this is the correct pattern
+✅ Only suggest changes to version management scripts if needed
+✅ Help with debugging version-related issues without touching placeholders
+✅ Point to this document when asked about VERSION_PLACEHOLDER
+
+### Version Management Flow
+1. **Development**: Manifests contain VERSION_PLACEHOLDER
+2. **CI/CD**: Pipeline replaces VERSION_PLACEHOLDER with actual version
+3. **Deployment**: Kubernetes gets versioned images
+4. **Rollback**: Easy to revert to previous versions
+
+### If You See VERSION_PLACEHOLDER
+- This is CORRECT and INTENTIONAL
+- Do NOT "fix" it
+- The CI/CD pipeline will handle version replacement
+- This ensures consistent deployments across environments
+
+### Version Management Commands
+```bash
+# Check version status
+make version-check
+
+# Show version information
+make version-info
+
+# Create new release
+./scripts/create-release.sh patch
+./scripts/create-release.sh minor
+./scripts/create-release.sh major
+
+# Debug version issues
+make version-debug
+```
+
+### Files That Should Contain VERSION_PLACEHOLDER
+- `k8s/deployment.yaml`
+- `k8s/service.yaml`
+- `k8s/ingress.yaml`
+- `k8s/hpa.yaml`
+- `k8s/network-policy.yaml`
+- `k8s/configmap.yaml`
+- `k8s/common-configmap.yaml`
+- All CronJob manifests
+
+### If Asked About VERSION_PLACEHOLDER
+- Explain it's intentional and part of the deployment system
+- Suggest using version management scripts instead
+- Never suggest manual replacement
+- Point to VERSION_PLACEHOLDER_GUIDE.md for details
+
+## Why This System Exists
+
+### Benefits
+- **Consistent versioning** across all Petrosa systems
+- **Automated deployments** through CI/CD pipelines
+- **No manual version management** in Kubernetes manifests
+- **Easy rollbacks** and version tracking
+- **Standardized deployment process** across all projects
+
+### How It Works
+1. **Git tags** provide the version source (e.g., `v1.0.1`)
+2. **CI/CD pipeline** automatically replaces VERSION_PLACEHOLDER
+3. **Kubernetes** gets the exact version for deployment
+4. **Monitoring** can track which version is running
+
+### Auto-Increment System
+- **Patch versions** increment automatically on main branch pushes
+- **Minor/Major versions** require manual release creation
+- **Local development** uses timestamp-based versions
+- **Production** uses semantic versioning
+
+## Troubleshooting
+
+### Common Issues
+1. **VERSION_PLACEHOLDER not replaced**: Check CI/CD pipeline
+2. **Version mismatch**: Verify git tags and deployment
+3. **Manual version committed**: Revert to VERSION_PLACEHOLDER
+
+### Debugging Commands
+```bash
+# Check for VERSION_PLACEHOLDER
+grep -r "VERSION_PLACEHOLDER" k8s/
+
+# Check for hardcoded versions
+grep -r "yurisa2/petrosa.*:v[0-9]" k8s/
+
+# Check deployed version
+kubectl --kubeconfig=k8s/kubeconfig.yaml get deployment -n petrosa-apps -o jsonpath='{.spec.template.spec.containers[0].image}'
+```
+
+## Summary
+
+**VERSION_PLACEHOLDER is intentional and correct. Never change it.**
+The CI/CD pipeline handles version replacement automatically.
+This system ensures reliable, consistent deployments across all Petrosa services.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -58,12 +58,12 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: petrosa-common-config
-                  key: log-level
+                  key: LOG_LEVEL
             - name: ENVIRONMENT
               valueFrom:
                 configMapKeyRef:
                   name: petrosa-common-config
-                  key: environment
+                  key: ENVIRONMENT
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Install git hooks to prevent VERSION_PLACEHOLDER changes
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+print_status "🔧 Installing git hooks for VERSION_PLACEHOLDER protection..."
+
+# Check if we're in a git repository
+if [ ! -d ".git" ]; then
+    print_error "❌ Not in a git repository"
+    print_error "   Please run this script from the root of a git repository"
+    exit 1
+fi
+
+# Create .git/hooks directory if it doesn't exist
+if [ ! -d ".git/hooks" ]; then
+    print_status "Creating .git/hooks directory..."
+    mkdir -p .git/hooks
+fi
+
+# Check if pre-commit hook already exists
+if [ -f ".git/hooks/pre-commit" ]; then
+    print_warning "⚠️  Pre-commit hook already exists"
+    read -p "Do you want to overwrite it? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        print_status "Installation aborted."
+        exit 0
+    fi
+fi
+
+# Copy pre-commit hook
+if [ -f "scripts/pre-commit-version-check.sh" ]; then
+    cp scripts/pre-commit-version-check.sh .git/hooks/pre-commit
+    chmod +x .git/hooks/pre-commit
+    print_success "✅ Pre-commit hook installed"
+else
+    print_error "❌ scripts/pre-commit-version-check.sh not found"
+    print_error "   Please ensure the script exists before installing hooks"
+    exit 1
+fi
+
+print_success ""
+print_success "🎉 Git hooks installation completed!"
+print_success ""
+print_success "The pre-commit hook will now prevent accidental VERSION_PLACEHOLDER changes."
+print_success ""
+print_success "To test the hook:"
+print_success "  1. Make a change to a k8s/*.yaml file"
+print_success "  2. Replace VERSION_PLACEHOLDER with a specific version"
+print_success "  3. Try to commit: git add k8s/deployment.yaml && git commit -m 'test'"
+print_success "  4. The commit should be blocked with an error message"
+print_success ""
+print_success "To remove the hook (not recommended):"
+print_success "  rm .git/hooks/pre-commit"
+print_success ""
+print_success "For more information, see: docs/CURSOR_AI_VERSION_RULES.md"

--- a/scripts/pre-commit-version-check.sh
+++ b/scripts/pre-commit-version-check.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Pre-commit hook to prevent VERSION_PLACEHOLDER changes
+# This hook ensures that VERSION_PLACEHOLDER is never accidentally modified
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+print_status "🔍 Checking for VERSION_PLACEHOLDER modifications..."
+
+# Check if any staged files contain VERSION_PLACEHOLDER changes
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if [ -z "$STAGED_FILES" ]; then
+    print_success "No staged files to check"
+    exit 0
+fi
+
+ERRORS_FOUND=0
+
+for file in $STAGED_FILES; do
+    # Only check YAML files in k8s directory
+    if [[ "$file" == k8s/*.yaml ]] || [[ "$file" == k8s/*.yml ]]; then
+        print_status "Checking $file..."
+        
+        # Check if VERSION_PLACEHOLDER was removed or changed
+        if git diff --cached "$file" | grep -q "^-.*VERSION_PLACEHOLDER"; then
+            print_error "❌ VERSION_PLACEHOLDER was removed or changed in $file"
+            print_error "   This is NOT allowed. VERSION_PLACEHOLDER must remain unchanged."
+            print_error "   The CI/CD pipeline will handle version replacement automatically."
+            ERRORS_FOUND=$((ERRORS_FOUND + 1))
+        fi
+        
+        # Check if a specific version was added instead of VERSION_PLACEHOLDER
+        if git diff --cached "$file" | grep -q "^+.*yurisa2/petrosa.*:v[0-9]"; then
+            print_error "❌ Specific version detected in $file"
+            print_error "   This is NOT allowed. Use VERSION_PLACEHOLDER instead."
+            print_error "   The CI/CD pipeline will handle version replacement automatically."
+            ERRORS_FOUND=$((ERRORS_FOUND + 1))
+        fi
+        
+        # Check if "latest" was added instead of VERSION_PLACEHOLDER
+        if git diff --cached "$file" | grep -q "^+.*yurisa2/petrosa.*:latest"; then
+            print_error "❌ 'latest' tag detected in $file"
+            print_error "   This is NOT allowed. Use VERSION_PLACEHOLDER instead."
+            print_error "   The CI/CD pipeline will handle version replacement automatically."
+            ERRORS_FOUND=$((ERRORS_FOUND + 1))
+        fi
+    fi
+done
+
+if [ $ERRORS_FOUND -gt 0 ]; then
+    print_error ""
+    print_error "🚨 VERSION_PLACEHOLDER violations found: $ERRORS_FOUND"
+    print_error ""
+    print_error "To fix these issues:"
+    print_error "1. Revert the changes to VERSION_PLACEHOLDER"
+    print_error "2. Use version management scripts instead:"
+    print_error "   - ./scripts/create-release.sh patch"
+    print_error "   - ./scripts/create-release.sh minor"
+    print_error "   - ./scripts/create-release.sh major"
+    print_error "3. Read docs/CURSOR_AI_VERSION_RULES.md for more information"
+    print_error ""
+    print_error "Commit aborted. Please fix the VERSION_PLACEHOLDER issues and try again."
+    exit 1
+fi
+
+print_success "✅ VERSION_PLACEHOLDER check passed"
+print_status "   All staged files maintain proper VERSION_PLACEHOLDER usage"

--- a/scripts/version-manager.sh
+++ b/scripts/version-manager.sh
@@ -1,0 +1,307 @@
+#!/bin/bash
+
+# Enhanced version manager with VERSION_PLACEHOLDER validation
+# Generates auto-incremental versions for local development and deployment
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to validate VERSION_PLACEHOLDER integrity
+validate_version_placeholders() {
+    print_status "Validating VERSION_PLACEHOLDER integrity..."
+    
+    # Check for VERSION_PLACEHOLDER in k8s files
+    PLACEHOLDER_COUNT=$(grep -r "VERSION_PLACEHOLDER" k8s/ 2>/dev/null | wc -l || echo "0")
+    
+    if [ "$PLACEHOLDER_COUNT" -eq 0 ]; then
+        print_error "❌ No VERSION_PLACEHOLDER found in k8s/ directory"
+        print_error "   This indicates the version system is broken"
+        print_error "   Expected to find VERSION_PLACEHOLDER in Kubernetes manifests"
+        return 1
+    fi
+    
+    # Check for hardcoded versions
+    HARDCODED_COUNT=$(grep -r "yurisa2/petrosa.*:v[0-9]" k8s/ 2>/dev/null | wc -l || echo "0")
+    
+    if [ "$HARDCODED_COUNT" -gt 0 ]; then
+        print_warning "⚠️  Found $HARDCODED_COUNT hardcoded versions in k8s/"
+        print_warning "   These should be VERSION_PLACEHOLDER instead"
+        grep -r "yurisa2/petrosa.*:v[0-9]" k8s/ 2>/dev/null || true
+        return 1
+    fi
+    
+    # Check for "latest" tags
+    LATEST_COUNT=$(grep -r "yurisa2/petrosa.*:latest" k8s/ 2>/dev/null | wc -l || echo "0")
+    
+    if [ "$LATEST_COUNT" -gt 0 ]; then
+        print_warning "⚠️  Found $LATEST_COUNT 'latest' tags in k8s/"
+        print_warning "   These should be VERSION_PLACEHOLDER instead"
+        grep -r "yurisa2/petrosa.*:latest" k8s/ 2>/dev/null || true
+        return 1
+    fi
+    
+    print_success "✅ VERSION_PLACEHOLDER validation passed"
+    print_status "   Found $PLACEHOLDER_COUNT VERSION_PLACEHOLDER references"
+    return 0
+}
+
+# Function to generate version
+generate_version() {
+    local version_type=$1
+
+    case $version_type in
+        "patch")
+            # Get latest version from git tags
+            LATEST_VERSION=$(git tag --sort=-version:refname | grep '^v[0-9]' | head -1)
+            if [ -z "$LATEST_VERSION" ]; then
+                VERSION="v1.0.0"
+            else
+                if [[ "$LATEST_VERSION" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+                    MAJOR="${BASH_REMATCH[1]}"
+                    MINOR="${BASH_REMATCH[2]}"
+                    PATCH="${BASH_REMATCH[3]}"
+                    NEW_PATCH=$((PATCH + 1))
+                    VERSION="v${MAJOR}.${MINOR}.${NEW_PATCH}"
+                else
+                    VERSION="v1.0.0"
+                fi
+            fi
+            ;;
+        "minor")
+            LATEST_VERSION=$(git tag --sort=-version:refname | grep '^v[0-9]' | head -1)
+            if [ -z "$LATEST_VERSION" ]; then
+                VERSION="v1.0.0"
+            else
+                if [[ "$LATEST_VERSION" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+                    MAJOR="${BASH_REMATCH[1]}"
+                    MINOR="${BASH_REMATCH[2]}"
+                    NEW_MINOR=$((MINOR + 1))
+                    VERSION="v${MAJOR}.${NEW_MINOR}.0"
+                else
+                    VERSION="v1.0.0"
+                fi
+            fi
+            ;;
+        "major")
+            LATEST_VERSION=$(git tag --sort=-version:refname | grep '^v[0-9]' | head -1)
+            if [ -z "$LATEST_VERSION" ]; then
+                VERSION="v1.0.0"
+            else
+                if [[ "$LATEST_VERSION" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+                    MAJOR="${BASH_REMATCH[1]}"
+                    NEW_MAJOR=$((MAJOR + 1))
+                    VERSION="v${NEW_MAJOR}.0.0"
+                else
+                    VERSION="v1.0.0"
+                fi
+            fi
+            ;;
+        "local")
+            # Generate local development version with timestamp
+            TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+            COMMIT_SHA=$(git rev-parse --short HEAD)
+            VERSION="local-${TIMESTAMP}-${COMMIT_SHA}"
+            ;;
+        *)
+            print_error "Unknown version type: $version_type"
+            print_error "Available types: patch, minor, major, local"
+            exit 1
+            ;;
+    esac
+
+    echo "$VERSION"
+}
+
+# Function to update Kubernetes manifests (for local testing only)
+update_k8s_manifests() {
+    local version=$1
+    local docker_username=${2:-"yurisa2"}
+
+    print_status "Updating Kubernetes manifests with version: $version"
+    print_warning "⚠️  This is for local testing only - DO NOT COMMIT these changes"
+
+    # Update deployment.yaml
+    if [ -f "k8s/deployment.yaml" ]; then
+        sed -i.bak "s|VERSION_PLACEHOLDER|${version}|g" k8s/deployment.yaml
+        sed -i.bak "s|yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER|${docker_username}/petrosa-binance-data-extractor:${version}|g" k8s/deployment.yaml
+        rm -f k8s/deployment.yaml.bak
+        print_success "Updated k8s/deployment.yaml"
+    fi
+
+    # Update other manifests if they contain VERSION_PLACEHOLDER
+    find k8s/ -name "*.yaml" -exec grep -l "VERSION_PLACEHOLDER" {} \; | while read file; do
+        sed -i.bak "s|VERSION_PLACEHOLDER|${version}|g" "$file"
+        rm -f "${file}.bak"
+        print_success "Updated $file"
+    done
+}
+
+# Function to revert Kubernetes manifests
+revert_k8s_manifests() {
+    print_status "Reverting Kubernetes manifests to VERSION_PLACEHOLDER..."
+    
+    # Revert all changes in k8s directory
+    git checkout k8s/
+    
+    print_success "✅ Kubernetes manifests reverted to VERSION_PLACEHOLDER"
+}
+
+# Function to show version information
+show_version_info() {
+    print_status "📦 Version Information"
+    echo "======================"
+    
+    # Current version
+    LATEST_VERSION=$(git tag --sort=-version:refname | grep '^v[0-9]' | head -1 || echo 'None')
+    echo "Latest version: $LATEST_VERSION"
+    
+    # Next versions
+    echo "Next patch version: $(generate_version patch)"
+    echo "Next minor version: $(generate_version minor)"
+    echo "Next major version: $(generate_version major)"
+    
+    # VERSION_PLACEHOLDER status
+    echo ""
+    print_status "🔍 VERSION_PLACEHOLDER Status:"
+    PLACEHOLDER_COUNT=$(grep -r "VERSION_PLACEHOLDER" k8s/ 2>/dev/null | wc -l || echo "0")
+    echo "VERSION_PLACEHOLDER references: $PLACEHOLDER_COUNT"
+    
+    # Git status
+    echo ""
+    print_status "📋 Git Status:"
+    git status --porcelain || echo "No changes"
+}
+
+# Function to debug version issues
+debug_version_issues() {
+    print_status "🐛 Version Debug Information"
+    echo "============================"
+    
+    # Git status
+    echo "Git status:"
+    git status --porcelain
+    echo ""
+    
+    # All git tags
+    echo "All git tags:"
+    git tag --sort=-version:refname
+    echo ""
+    
+    # VERSION_PLACEHOLDER in k8s/
+    echo "VERSION_PLACEHOLDER in k8s/:"
+    grep -r "VERSION_PLACEHOLDER" k8s/ 2>/dev/null || echo "None found"
+    echo ""
+    
+    # Hardcoded versions in k8s/
+    echo "Hardcoded versions in k8s/:"
+    grep -r "yurisa2/petrosa.*:v[0-9]" k8s/ 2>/dev/null || echo "None found"
+    echo ""
+    
+    # Latest tags in k8s/
+    echo "'latest' tags in k8s/:"
+    grep -r "yurisa2/petrosa.*:latest" k8s/ 2>/dev/null || echo "None found"
+    echo ""
+    
+    # CI/CD pipeline status
+    if [ -f ".github/workflows/ci-cd.yml" ]; then
+        echo "CI/CD pipeline file exists: ✅"
+    else
+        echo "CI/CD pipeline file missing: ❌"
+    fi
+    
+    # Version management scripts
+    if [ -f "scripts/create-release.sh" ]; then
+        echo "Create release script exists: ✅"
+    else
+        echo "Create release script missing: ❌"
+    fi
+}
+
+# Function to show usage
+show_usage() {
+    echo "Usage: $0 [command] [options]"
+    echo ""
+    echo "Commands:"
+    echo "  generate [patch|minor|major|local]  - Generate version"
+    echo "  validate                            - Validate VERSION_PLACEHOLDER integrity"
+    echo "  info                                - Show version information"
+    echo "  debug                               - Debug version issues"
+    echo "  update-local [version]              - Update manifests for local testing"
+    echo "  revert                              - Revert manifests to VERSION_PLACEHOLDER"
+    echo ""
+    echo "Examples:"
+    echo "  $0 generate patch                   # Generate next patch version"
+    echo "  $0 validate                         # Check VERSION_PLACEHOLDER integrity"
+    echo "  $0 info                             # Show version information"
+    echo "  $0 debug                            # Debug version issues"
+    echo "  $0 update-local v1.0.1-test         # Update for local testing"
+    echo "  $0 revert                           # Revert to VERSION_PLACEHOLDER"
+    echo ""
+    echo "Note: Use ./scripts/create-release.sh for creating actual releases"
+}
+
+# Main function
+main() {
+    local command=$1
+    local option=$2
+    
+    case $command in
+        "generate")
+            if [ -z "$option" ]; then
+                print_error "Version type required: patch, minor, major, or local"
+                exit 1
+            fi
+            VERSION=$(generate_version "$option")
+            echo "$VERSION"
+            ;;
+        "validate")
+            validate_version_placeholders
+            ;;
+        "info")
+            show_version_info
+            ;;
+        "debug")
+            debug_version_issues
+            ;;
+        "update-local")
+            if [ -z "$option" ]; then
+                print_error "Version required for local testing"
+                exit 1
+            fi
+            update_k8s_manifests "$option"
+            print_warning "⚠️  Remember to run '$0 revert' before committing"
+            ;;
+        "revert")
+            revert_k8s_manifests
+            ;;
+        *)
+            show_usage
+            exit 1
+            ;;
+    esac
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
## 🔧 Version Protection & Compliance Improvements

### Changes Made
- ✅ **Added VERSION_PLACEHOLDER protection scripts**
- ✅ **Updated deployment configuration for compliance**  
- ✅ **Added git hooks for version management**
- ✅ **Updated Makefile with new targets**

### Benefits
- **Prevents manual VERSION_PLACEHOLDER modifications**
- **Maintains deployment compliance across services**
- **Automated version management through git hooks**
- **Consistent development workflow**

### Files Added
-  - Version management guidelines
- [0;34m[INFO][0m 🔧 Installing git hooks for VERSION_PLACEHOLDER protection...
[1;33m[WARNING][0m ⚠️  Pre-commit hook already exists

[0;32m[SUCCESS][0m ✅ Pre-commit hook installed
[0;32m[SUCCESS][0m 
[0;32m[SUCCESS][0m 🎉 Git hooks installation completed!
[0;32m[SUCCESS][0m 
[0;32m[SUCCESS][0m The pre-commit hook will now prevent accidental VERSION_PLACEHOLDER changes.
[0;32m[SUCCESS][0m 
[0;32m[SUCCESS][0m To test the hook:
[0;32m[SUCCESS][0m   1. Make a change to a k8s/*.yaml file
[0;32m[SUCCESS][0m   2. Replace VERSION_PLACEHOLDER with a specific version
[0;32m[SUCCESS][0m   3. Try to commit: git add k8s/deployment.yaml && git commit -m 'test'
[0;32m[SUCCESS][0m   4. The commit should be blocked with an error message
[0;32m[SUCCESS][0m 
[0;32m[SUCCESS][0m To remove the hook (not recommended):
[0;32m[SUCCESS][0m   rm .git/hooks/pre-commit
[0;32m[SUCCESS][0m 
[0;32m[SUCCESS][0m For more information, see: docs/CURSOR_AI_VERSION_RULES.md - Git hooks installer
- [0;34m[INFO][0m 🔍 Checking for VERSION_PLACEHOLDER modifications...
[0;32m[SUCCESS][0m No staged files to check - Pre-commit version validation
- Usage: scripts/version-manager.sh [command] [options]

Commands:
  generate [patch|minor|major|local]  - Generate version
  validate                            - Validate VERSION_PLACEHOLDER integrity
  info                                - Show version information
  debug                               - Debug version issues
  update-local [version]              - Update manifests for local testing
  revert                              - Revert manifests to VERSION_PLACEHOLDER

Examples:
  scripts/version-manager.sh generate patch                   # Generate next patch version
  scripts/version-manager.sh validate                         # Check VERSION_PLACEHOLDER integrity
  scripts/version-manager.sh info                             # Show version information
  scripts/version-manager.sh debug                            # Debug version issues
  scripts/version-manager.sh update-local v1.0.1-test         # Update for local testing
  scripts/version-manager.sh revert                           # Revert to VERSION_PLACEHOLDER

Note: Use ./scripts/create-release.sh for creating actual releases - Version management utilities

These changes ensure consistent version handling across all Petrosa services.