### PR TITLE
feat: Integrate OpenTelemetry auto-instrumentation in deployment

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -26,12 +26,15 @@ spec:
           image: yurisa2/petrosa-socket-client:VERSION_PLACEHOLDER
           imagePullPolicy: Always
           command:
+            - opentelemetry-instrument
             - python
             - '-m'
             - socket_client.main
           args:
             - run
           env:
+            - name: OTEL_NO_AUTO_INIT
+              value: "1"
             - name: BINANCE_WS_URL
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Overview
This PR integrates OpenTelemetry auto-instrumentation into the socket client deployment for centralized observability.

## Changes
- ✅ Add opentelemetry-instrument command to deployment
- ✅ Set OTEL_NO_AUTO_INIT for manual control
- ✅ Enable automatic instrumentation for WebSocket client
- ✅ Integrate with Grafana Cloud via OTLP endpoint

## Security
- No credentials modified
- Uses existing environment variables from configmap

## Testing
- Pre-commit hooks passed (VERSION_PLACEHOLDER check)
- Deployment manifest validated