### PR TITLE
feat: Add aiohttp OpenTelemetry traces instrumentation

### DIFF
--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -35,12 +35,16 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: nats
-  # Allow connection to OpenTelemetry collector
+  # Allow connection to OpenTelemetry collector (Grafana Alloy)
   - ports:
     - port: 4317
       protocol: TCP
-    - port: 14250
+    - port: 4318
       protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: observability
   # Allow connection to health check endpoints within the cluster
   - ports:
     - port: 8080

--- a/socket_client/health/server.py
+++ b/socket_client/health/server.py
@@ -14,6 +14,14 @@ from structlog import get_logger
 
 logger = get_logger(__name__)
 
+# Instrument aiohttp for OpenTelemetry traces
+try:
+    from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
+    AioHttpClientInstrumentor().instrument()
+    logger.info("✅ aiohttp client instrumented for OpenTelemetry traces")
+except Exception as e:
+    logger.warning(f"⚠️  Could not instrument aiohttp client: {e}")
+
 
 class HealthServer:
     """HTTP server for health checks and monitoring."""
@@ -32,6 +40,15 @@ class HealthServer:
         self.runner: Optional[web.AppRunner] = None
         self.site: Optional[web.TCPSite] = None
         self.start_time = time.time()
+
+        # Instrument aiohttp server for OpenTelemetry traces
+        try:
+            from opentelemetry import trace
+            from opentelemetry.instrumentation.aiohttp_server import AioHttpServerInstrumentor
+            AioHttpServerInstrumentor().instrument(server=self.app)
+            self.logger.info("✅ aiohttp server instrumented for OpenTelemetry traces")
+        except Exception as e:
+            self.logger.warning(f"⚠️  Could not instrument aiohttp server: {e}")
 
         # Setup routes
         self.app.router.add_get("/healthz", self.health_check)


### PR DESCRIPTION
## Changes
- Add AioHttpClientInstrumentor and AioHttpServerInstrumentor
- Enable automatic trace generation for health check HTTP requests
- Update network policy to specify observability namespace for OTLP

## Testing
- aiohttp server will generate traces for health endpoints
- Network policy allows OTLP connections
- Compatible with Grafana Cloud Tempo setup

## Related
- Part of Grafana Cloud observability migration
- Enables trace collection from socket-client health endpoints