### PR TITLE
chore: trigger redeployment to pick up fixed shared configmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,3 +406,4 @@ For support and questions:
 - [Petrosa Data Extractor](https://github.com/petrosa/petrosa-binance-data-extractor) - Historical data extraction
 # Trigger deployment with updated kubeconfig
 # Test deployment with updated kubeconfig
+# Trigger redeployment


### PR DESCRIPTION
## Purpose
Forces socket-client to redeploy so pods restart and pick up the corrected shared configmap.

## Context
Shared configmap architecture fixed. Pods need restart to pick up correct config.

## Impact
✅ socket-client pods restart
✅ Pick up correct OTEL endpoint
✅ Traces will appear in Grafana Cloud