### PR TITLE
fix: add ENABLE_LOGS, ENABLE_METRICS, and ENABLE_TRACES environment variables

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -74,6 +74,21 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: ENABLE_OTEL
+            - name: ENABLE_LOGS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: ENABLE_LOGS
+            - name: ENABLE_METRICS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: ENABLE_METRICS
+            - name: ENABLE_TRACES
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: ENABLE_TRACES
             - name: OTEL_SERVICE_VERSION
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Problem
The socket-client was not exporting logs to OTLP/Grafana because the required environment variables were missing from the deployment configuration.

The pod startup showed this error:
```
⚠️  Logger provider not configured - logging export not available
```

## Root Cause
The `ENABLE_LOGS`, `ENABLE_METRICS`, and `ENABLE_TRACES` environment variables exist in the `petrosa-common-config` ConfigMap but were not being injected into the socket-client deployment.

## Solution
Added the missing environment variables to the deployment.yaml:
- `ENABLE_LOGS` - enables OTLP log export
- `ENABLE_METRICS` - enables OTLP metrics export
- `ENABLE_TRACES` - enables OTLP traces export

## Impact
After this fix:
- ✅ Logs will be properly exported to Grafana/Loki via OTLP
- ✅ Metrics will be exported to Grafana via OTLP
- ✅ Traces will be exported to Grafana Tempo via OTLP
- ✅ Full observability restored for socket-client service

## Testing
- Deployment will create new pods with the environment variables
- Startup logs should show: `✅ OpenTelemetry logging export configured`
- No more `Logger provider not configured` warnings