### PR TITLE
fix: call setup_telemetry() explicitly to enable OTLP logging

### DIFF
--- a/socket_client/main.py
+++ b/socket_client/main.py
@@ -47,13 +47,20 @@ class SocketClientService:
         """Initialize the service."""
         self.logger = setup_logging(level=constants.LOG_LEVEL)
 
-        # Attach OTLP logging handler AFTER setup_logging() configures logging
+        # Set up OpenTelemetry and attach OTLP logging handler AFTER setup_logging()
         # This ensures the handler survives any logging reconfiguration
         try:
             import otel_init
+            # Call setup_telemetry explicitly since OTEL_NO_AUTO_INIT=1 prevents auto-setup
+            otel_init.setup_telemetry(
+                service_name=constants.OTEL_SERVICE_NAME,
+                service_version=constants.OTEL_SERVICE_VERSION,
+                otlp_endpoint=constants.OTEL_EXPORTER_OTLP_ENDPOINT
+            )
+            # Attach the OTLP logging handler to the root logger
             otel_init.attach_logging_handler_simple()
         except Exception as e:
-            print(f"⚠️  Failed to attach OTLP handler: {e}")
+            print(f"⚠️  Failed to set up OTLP: {e}")
 
         self.websocket_client: Optional[BinanceWebSocketClient] = None
         self.health_server: Optional[HealthServer] = None


### PR DESCRIPTION
## Critical Fix for OTLP Logging

### Problem
Even after adding the environment variables in PR #26, the logger provider was still not being configured, resulting in:
```
⚠️  Logger provider not configured - logging export not available
```

### Root Cause
The issue was that `OTEL_NO_AUTO_INIT=1` is set in the deployment configuration, which prevents the automatic setup of OpenTelemetry in the `otel_init.py` module. The code was only calling `attach_logging_handler_simple()` but never calling `setup_telemetry()` to create the logger provider.

###  Solution
Explicitly call `setup_telemetry()` in the service's `__init__` method before attaching the logging handler. This ensures:
1. ✅ Tracer provider is configured
2. ✅ Meter provider is configured  
3. ✅ **Logger provider is configured**
4. ✅ OTLP logging handler can be attached successfully
5. ✅ Logs are exported to Grafana/Loki

### Changes
- Modified `socket_client/main.py` to explicitly call `setup_telemetry()` with proper parameters
- Ensures telemetry setup happens AFTER `setup_logging()` but BEFORE `attach_logging_handler_simple()`

### Expected Results
After deployment:
- ✅ Startup logs will show: `✅ OpenTelemetry logging export configured`
- ✅ Startup logs will show: `✅ OTLP logging handler attached`
- ✅ No more `Logger provider not configured` warnings
- ✅ Full observability with logs, metrics, and traces exported to Grafana

### Related
- Fixes issue introduced by `OTEL_NO_AUTO_INIT=1` flag
- Complements PR #26 (environment variables)