### PR TITLE
fix: Remove OTEL_NO_AUTO_INIT to enable trace collection

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -37,8 +37,6 @@ spec:
           args:
             - run
           env:
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
             - name: BINANCE_WS_URL
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Problem
socket-client is missing from Grafana Cloud Tempo - no traces being collected.

## Root Cause
- Deployment has `OTEL_NO_AUTO_INIT=1` set
- Using `opentelemetry-instrument` wrapper for auto-instrumentation
- The flag prevents the wrapper from properly auto-configuring OTEL from environment variables

## Solution
Remove `OTEL_NO_AUTO_INIT` from deployment to allow proper auto-instrumentation:
- ✅ `opentelemetry-instrument` wrapper will auto-configure from env vars
- ✅ Code has fallback logic (line 31 in main.py) to setup OTEL when var is not set  
- ✅ All OTEL env vars are already configured in deployment

## Testing
- [ ] CI/CD will deploy changes
- [ ] Verify trace initialization in pod logs
- [ ] Confirm socket-client appears in Grafana Cloud Tempo

## Expected Result
socket-client will send complete traces to Grafana Cloud, enabling distributed tracing across the Petrosa ecosystem.