### PR TITLE
[INFRA] Restore and Standardize Local Test Environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ requests>=2.31.0
 aiohttp>=3.8.0
 
 # FastAPI for configuration API
-fastapi>=0.104.0
+fastapi>=0.110.0
 uvicorn[standard]>=0.24.0
 httpx>=0.25.0
 # Configuration and environment
@@ -48,3 +48,4 @@ cryptography>=41.0.0
 
 # Prometheus metrics
 prometheus-client>=0.19.0
+starlette>=0.37.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,18 @@
+import os
+import pytest
+
+# Disable OpenTelemetry auto-initialization during tests
+os.environ['OTEL_NO_AUTO_INIT'] = '1'
+os.environ['OTEL_SDK_DISABLED'] = 'true'
+os.environ['OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED'] = 'false'
+
+def pytest_configure(config):
+    """
+    Setup before any tests are run.
+    """
+    os.environ['OTEL_NO_AUTO_INIT'] = '1'
+    os.environ['OTEL_SDK_DISABLED'] = 'true'
+
 """
 Pytest configuration and fixtures for the Socket Client service.
 """


### PR DESCRIPTION
## Problem Statement
Standardizes the local development and test environment across the Petrosa ecosystem.

## Changes
- Upgraded fastapi/starlette to resolve HTTPX incompatibility
- Added OTel shield to conftest.py to disable telemetry during tests
- Installed missing pytest plugins

Addresses PetroSa2/petrosa_k8s#137