### PR TITLE
docs: add REFERENCE.md pointing to petrosa_k8s Hub

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,0 +1,12 @@
+# Documentation Reference
+
+This repository is part of the PetroSa trading ecosystem. While local implementation details are kept here, the **"Universal Truth"** (System architecture, global business logic, and cross-service PRDs) has been centralized in the `petrosa_k8s` repository.
+
+## 🔗 Global Documentation Hub
+
+- **System Topology**: [petrosa_k8s/SYSTEM_TOPOLOGY.md](../../petrosa_k8s/SYSTEM_TOPOLOGY.md)
+- **Global Contracts**: [petrosa_k8s/_memory/architecture/global-contracts.md](../../petrosa_k8s/_memory/architecture/global-contracts.md)
+- **LLM Strategist PRD**: [petrosa_k8s/_memory/prds/llm-strategist/](../../petrosa_k8s/_memory/prds/llm-strategist/)
+- **Remediation Status**: [petrosa_k8s/_memory/prds/remediation_status.md](../../petrosa_k8s/_memory/prds/remediation_status.md)
+
+Please refer to the `petrosa_k8s` repository for all high-level system design and cross-repo coordination.


### PR DESCRIPTION
Reference centralized documentation hub in petrosa_k8s as part of #355.