### PR TITLE
feat: 121 - migrate socket-client metrics to OTel SDK instruments

### DIFF
--- a/socket_client/core/client.py
+++ b/socket_client/core/client.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 import nats
 import websockets
 from nats.aio.client import Client as NATSClient
+from opentelemetry import metrics
 from structlog import get_logger
 
 import constants
@@ -32,6 +33,37 @@ try:
     tracer = get_tracer(__name__)
 except ImportError:
     tracer = None
+
+# OpenTelemetry metrics — instruments emit through the OTLP push pipeline wired
+# by setup_telemetry() in main.py. get_meter() returns a proxy meter before the
+# MeterProvider is installed, so module-level creation is safe.
+_meter = metrics.get_meter(__name__)
+_messages_forwarded = _meter.create_counter(
+    "socket_client_messages_forwarded_total",
+    description="Binance WS messages successfully published to NATS",
+)
+_messages_dropped = _meter.create_counter(
+    "socket_client_messages_dropped_total",
+    description="Messages dropped (queue full or NATS disconnect)",
+)
+_reconnect_attempts = _meter.create_counter(
+    "socket_client_reconnect_attempts_total",
+    description="WebSocket reconnection attempts",
+)
+_connection_errors = _meter.create_counter(
+    "socket_client_connection_errors_total",
+    description="WebSocket or NATS connection failures",
+)
+_processing_time = _meter.create_histogram(
+    "socket_client_message_processing_seconds",
+    description="Time from queue dequeue to NATS publish",
+    unit="s",
+)
+_queue_wait_time = _meter.create_histogram(
+    "socket_client_queue_wait_seconds",
+    description="Time a worker waited on the queue before dequeue",
+    unit="s",
+)
 
 
 class BinanceWebSocketClient:
@@ -258,6 +290,7 @@ class BinanceWebSocketClient:
 
         except Exception as e:
             self.logger.error(f"Failed to connect to WebSocket: {e}")
+            _connection_errors.add(1, {"service": "socket-client", "type": "websocket"})
             if span:
                 span.record_exception(e)
             self.is_connected = False
@@ -279,6 +312,7 @@ class BinanceWebSocketClient:
 
         except Exception as e:
             self.logger.error(f"Failed to connect to NATS: {e}")
+            _connection_errors.add(1, {"service": "socket-client", "type": "nats"})
             raise
 
     async def _websocket_listener(self) -> None:
@@ -302,6 +336,9 @@ class BinanceWebSocketClient:
                         self.message_queue.put_nowait(data)
                     except asyncio.QueueFull:
                         self.dropped_messages += 1
+                        _messages_dropped.add(
+                            1, {"service": "socket-client", "reason": "queue_full"}
+                        )
                         self.logger.warning(
                             "Message queue full, dropping message",
                             dropped_count=self.dropped_messages,
@@ -332,6 +369,7 @@ class BinanceWebSocketClient:
         while self.is_running:
             try:
                 # Get message from queue with timeout
+                wait_start = time.perf_counter()
                 try:
                     data = await asyncio.wait_for(
                         self.message_queue.get(),
@@ -339,6 +377,9 @@ class BinanceWebSocketClient:
                     )
                 except TimeoutError:
                     continue
+                _queue_wait_time.record(
+                    time.perf_counter() - wait_start, {"service": "socket-client"}
+                )
 
                 # Process message
                 await self._process_single_message(data)
@@ -371,6 +412,7 @@ class BinanceWebSocketClient:
 
     async def _do_process_single_message(self, data: dict, span: Any = None) -> None:
         """Internal method for processing a single message."""
+        process_start = time.perf_counter()
         try:
             # Validate message format - Binance WebSocket messages come as direct JSON objects
             # Note: isinstance check is defensive code for runtime safety, though type hints declare dict
@@ -410,6 +452,13 @@ class BinanceWebSocketClient:
                     )
 
                     self.processed_messages += 1
+                    _messages_forwarded.add(
+                        1, {"service": "socket-client", "stream": stream_name}
+                    )
+                    _processing_time.record(
+                        time.perf_counter() - process_start,
+                        {"service": "socket-client", "stream": stream_name},
+                    )
                     if span:
                         span.set_attribute("published", True)
 
@@ -440,6 +489,9 @@ class BinanceWebSocketClient:
             else:
                 self.logger.warning("NATS client not connected, dropping message")
                 self.dropped_messages += 1
+                _messages_dropped.add(
+                    1, {"service": "socket-client", "reason": "nats_disconnected"}
+                )
                 if span:
                     span.set_attribute("error", "nats_not_connected")
 
@@ -626,6 +678,7 @@ class BinanceWebSocketClient:
 
             except Exception as e:
                 self.reconnect_attempts += 1
+                _reconnect_attempts.add(1, {"service": "socket-client"})
                 self.logger.error(
                     f"Reconnection attempt {self.reconnect_attempts} failed: {e}"
                 )

--- a/socket_client/health/server.py
+++ b/socket_client/health/server.py
@@ -10,33 +10,9 @@ from datetime import datetime
 from typing import Any, Optional, cast
 
 from aiohttp import web
-from prometheus_client import Counter, Gauge, generate_latest
 from structlog import get_logger
 
 logger = get_logger(__name__)
-
-# Prometheus metrics
-WEBSOCKET_CONNECTED = Gauge(
-    "websocket_connected", "WebSocket connection status (1=connected, 0=disconnected)"
-)
-WEBSOCKET_MESSAGES_PROCESSED = Counter(
-    "websocket_messages_processed_total", "Total WebSocket messages processed"
-)
-WEBSOCKET_MESSAGES_DROPPED = Counter(
-    "websocket_messages_dropped_total", "Total WebSocket messages dropped"
-)
-WEBSOCKET_RECONNECT_ATTEMPTS = Counter(
-    "websocket_reconnect_attempts_total", "Total WebSocket reconnection attempts"
-)
-NATS_CONNECTED = Gauge(
-    "nats_connected", "NATS connection status (1=connected, 0=disconnected)"
-)
-NATS_MESSAGES_PUBLISHED = Counter(
-    "nats_messages_published_total", "Total messages published to NATS"
-)
-SERVICE_UPTIME = Gauge("service_uptime_seconds", "Service uptime in seconds")
-MEMORY_USAGE = Gauge("memory_usage_bytes", "Memory usage in bytes")
-CPU_USAGE = Gauge("cpu_usage_percent", "CPU usage percentage")
 
 
 class HealthServer:
@@ -149,30 +125,21 @@ class HealthServer:
             )
 
     async def metrics(self, request: web.Request) -> web.Response:
-        """Metrics endpoint for Prometheus monitoring."""
-        try:
-            # Update gauge metrics with current values
-            uptime = time.time() - self.start_time
-            SERVICE_UPTIME.set(uptime)
+        """Metrics endpoint (retained for compatibility).
 
-            memory_mb = self._get_memory_usage()
-            MEMORY_USAGE.set(memory_mb * 1024 * 1024)  # Convert MB to bytes
-
-            cpu = self._get_cpu_usage()
-            CPU_USAGE.set(cpu)
-
-            # Generate Prometheus-format metrics
-            metrics_output = generate_latest()
-
-            return web.Response(
-                body=metrics_output,
-                headers={"Content-Type": "text/plain; version=0.0.4; charset=utf-8"},
-                status=200,
-            )
-
-        except Exception as e:
-            self.logger.error(f"Metrics endpoint failed: {e}")
-            return web.Response(text=f"# Error generating metrics: {e}\n", status=500)
+        Application metrics are now emitted as OTel SDK instruments and shipped
+        via the OTLP push pipeline configured by ``setup_telemetry()`` — they are
+        no longer exposed for Prometheus scraping here. The route is preserved so
+        existing probes/references do not 404.
+        """
+        return web.Response(
+            text=(
+                "# socket-client metrics are exported via OTLP push "
+                "(OpenTelemetry), not Prometheus scrape\n"
+            ),
+            headers={"Content-Type": "text/plain; version=0.0.4; charset=utf-8"},
+            status=200,
+        )
 
     async def root(self, request: web.Request) -> web.Response:
         """Root endpoint with service information."""

--- a/tests/integration/test_health_endpoints.py
+++ b/tests/integration/test_health_endpoints.py
@@ -101,24 +101,27 @@ class TestMetricsEndpoint(AioHTTPTestCase):
 
         data = await resp.text()
         assert isinstance(data, str)
-        assert "# HELP" in data or "service_uptime_seconds" in data
 
     @unittest_run_loop
-    async def test_metrics_includes_uptime(self):
-        """Test metrics includes uptime."""
+    async def test_metrics_reports_otlp_push(self):
+        """Metrics are now exported via OTLP push, not Prometheus scrape.
+
+        The /metrics route is retained for compatibility but no longer emits
+        Prometheus exposition format; it returns an informational note instead.
+        """
         resp = await self.client.request("GET", "/metrics")
         data = await resp.text()
 
-        assert "service_uptime_seconds" in data
+        assert "OTLP push" in data
 
     @unittest_run_loop
-    async def test_metrics_includes_start_time(self):
-        """Test metrics includes start time."""
-        # Check for another metric that should be present
+    async def test_metrics_has_no_prometheus_payload(self):
+        """The scrape endpoint must not emit Prometheus exposition output."""
         resp = await self.client.request("GET", "/metrics")
         data = await resp.text()
 
-        assert "memory_usage_bytes" in data
+        assert "# HELP" not in data
+        assert "service_uptime_seconds" not in data
 
 
 class TestHealthServerStartStop(AioHTTPTestCase):


### PR DESCRIPTION
## Summary

Implements `PetroSa2/petrosa-socket-client#121` — full migration of socket-client metrics from `prometheus_client` (scrape) to OTel SDK instruments shipped through the already-configured OTLP push pipeline.

- **`socket_client/core/client.py`** — obtains a meter via `from opentelemetry import metrics; _meter = metrics.get_meter(__name__)` (module level; `get_meter()` returns a proxy meter before the `MeterProvider` is installed by `setup_telemetry()`, so module-level creation is safe). Defines the six instruments from AC3 and wires `.add()` / `.record()` at the eight counting call sites:

  | Instrument | Type | Call site |
  |---|---|---|
  | `socket_client_messages_forwarded_total` | Counter | `_do_process_single_message` publish success |
  | `socket_client_messages_dropped_total` | Counter | queue-full (`_websocket_listener`) + NATS-disconnect (`_do_process_single_message`) |
  | `socket_client_reconnect_attempts_total` | Counter | `_handle_disconnection` |
  | `socket_client_connection_errors_total` | Counter | `_do_connect_websocket` + `_connect_nats` exception paths |
  | `socket_client_message_processing_seconds` | Histogram | dequeue → NATS publish |
  | `socket_client_queue_wait_seconds` | Histogram | wraps the worker's `queue.get()` await |

- **`socket_client/health/server.py`** — removes the nine never-incremented `prometheus_client` globals and the `from prometheus_client import Counter, Gauge, generate_latest` import (AC1).

## Acceptance criteria

- **AC1** ✅ nine prometheus globals + import removed from `health/server.py`.
- **AC2** ✅ meter created at module level via `opentelemetry.metrics.get_meter(__name__)`.
- **AC3** ✅ six instruments defined and wired at all eight call sites.
- **AC4** ✅ every `.add()`/`.record()` carries `{"service": "socket-client"}` plus a context attribute (`stream`, `reason`, or `type`). Reconnect attempts carry only `service` (no context attribute applicable). Resource-level attributes are left to `setup_telemetry()` and not duplicated.
- **AC5** ⏳ requires post-canary verification in Grafana Cloud — cannot be confirmed in CI; to be validated after deploy.
- **AC6** ✅ `ruff check .` passes; `mypy` introduces **no new errors** (the two pre-existing `psutil` stub / `no-any-return` findings in the unchanged `_get_memory_usage`/`_get_cpu_usage` helpers exist on `main` and are non-blocking in CI); full test suite: **191 passed, 1 xfailed**, coverage 76% (threshold 40%).
- **AC7** ✅ see below.

## AC7 — fate of the `/metrics` Prometheus scrape endpoint

**Decision: preserved as an informational stub** (route kept, payload replaced).

Rationale: with the nine `prometheus_client` globals and `generate_latest()` removed, the endpoint can no longer emit Prometheus exposition format. Application metrics now leave the process exclusively via the OTLP push pipeline (`setup_telemetry()` → `OTLPMetricExporter`), so a scrape endpoint is redundant. Rather than delete the route — which risks a 404 for any lingering probe, ServiceMonitor, or manifest reference — `/metrics` now returns HTTP 200 with a short text note (`# socket-client metrics are exported via OTLP push (OpenTelemetry), not Prometheus scrape`). Removing the now-orphaned scrape config / any ServiceMonitor is deferred to the k8s manifest work tracked under `PetroSa2/petrosa_k8s#664` (explicitly out of scope here).

## Notes / scope

- `prometheus-client` is left in `requirements.txt`. Unlike sibling ticket `#126` (cio), this ticket's ACs do **not** ask to prune the dependency, and editing `requirements.txt` is outside the declared two-file production scope. It is now unused by socket-client and can be removed in a follow-up.
- The two `_get_memory_usage`/`_get_cpu_usage` helpers in `health/server.py` are retained unchanged — they are exercised by `tests/unit/test_health_server.py` and are not `prometheus_client` code.
- `tests/integration/test_health_endpoints.py::TestMetricsEndpoint` was updated to assert the new OTLP-push contract (the old assertions checked for Prometheus output this ticket intentionally removes); required so CI (AC6) reflects the intended behavior change.

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy` — no new errors vs `main`
- [x] full `pytest tests/` — 191 passed, 1 xfailed, 76% coverage
- [ ] post-deploy: confirm non-zero `socket_client_messages_forwarded_total` and `socket_client_message_processing_seconds` series in Grafana Cloud (AC5)

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)
