### PR TITLE
test: verify Copilot auto-review disabled (petrosa_k8s#734 AC3)

### DIFF
--- a/docs/.copilot-review-test-2026-05-29.md
+++ b/docs/.copilot-review-test-2026-05-29.md
@@ -1,0 +1,2 @@
+Test PR for petrosa_k8s#734 AC3 — verify native Copilot auto-review stays off.
+Opened: 2026-05-29. Will be closed without merge.


### PR DESCRIPTION
**Test PR — will be closed without merge.**

Verifying AC3 of petrosa_k8s#734: confirm native GitHub Copilot Code Review does **not** auto-fire on a fresh PR in a previously-affected repo (socket-client #122 was the canonical incident).

**Expected:**
- No `Copilot` workflow run (event=dynamic) appears in `gh run list`.
- No `Copilot` (or copilot-pull-request-reviewer bot) entry in `reviewRequests`.
- Only the #707 centralized `copilot-review` check posts to the rollup after CI.

Will close this PR ~60s after observation.